### PR TITLE
fix: bump openssl to 0.10.80 (GHSA-phqj-4mhp-q6mq)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1126,9 +1126,9 @@ checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "openssl"
-version = "0.10.79"
+version = "0.10.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf0b434746ee2832f4f0baf10137e1cabb18cbe6912c69e2e33263c45250f542"
+checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -1157,9 +1157,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.115"
+version = "0.9.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "158fe5b292746440aa6e7a7e690e55aeb72d41505e2804c23c6973ad0e9c9781"
+checksum = "f28a22dc7140cda5f096e5e7724a6962ca81a7f8bfd2979f9b18c11af56318c4"
 dependencies = [
  "cc",
  "libc",


### PR DESCRIPTION
# Summary

- Bump transitive dependency `openssl` 0.10.79 → 0.10.80 to patch CVE GHSA-phqj-4mhp-q6mq
- Bump `openssl-sys` 0.9.115 → 0.9.116 (required by openssl 0.10.80)
- Resolves Dependabot alert #23 (potential out-of-bounds write in AES-KW-PAD cipher handling)